### PR TITLE
Prevent `SetProduct` from being used for a tuple

### DIFF
--- a/src/main/scala/com/github/tarao/slickjdbc/getresult/GetResult.scala
+++ b/src/main/scala/com/github/tarao/slickjdbc/getresult/GetResult.scala
@@ -169,20 +169,20 @@ object TypeBinder {
 
 trait AutoUnwrapOption {
   implicit def some[T](implicit
-    check: NoOption[T], // We do this to enable a diagnostic type
-                        // error by CheckGetter.  Otherwise an
-                        // implicit expansion of an unknown type fails
-                        // on divergence.
+    check: IsNotOption[T], // We do this to enable a diagnostic type
+                           // error by CheckGetter.  Otherwise an
+                           // implicit expansion of an unknown type
+                           // fails on divergence.
     option: TypeBinder[Option[T]]
   ): TypeBinder[T] = option.map(_.get) // throws
 }
 object AutoUnwrapOption extends AutoUnwrapOption
 
-sealed trait NoOption[+T]
-object NoOption {
-  implicit def some[T]: NoOption[T] = new NoOption[T] {}
+sealed trait IsNotOption[+T]
+object IsNotOption {
+  implicit def some[T]: IsNotOption[T] = new IsNotOption[T] {}
   // $COVERAGE-OFF$
-  implicit def ambig1[T]: NoOption[Option[T]] = sys.error("unexpected")
-  implicit def ambig2[T]: NoOption[Option[T]] = sys.error("unexpected")
+  implicit def ambig1[T]: IsNotOption[Option[T]] = sys.error("unexpected")
+  implicit def ambig2[T]: IsNotOption[Option[T]] = sys.error("unexpected")
   // $COVERAGE-ON$
 }

--- a/src/main/scala/com/github/tarao/slickjdbc/getresult/GetResult.scala
+++ b/src/main/scala/com/github/tarao/slickjdbc/getresult/GetResult.scala
@@ -42,6 +42,8 @@ object GetResult {
     }) }
 }
 
+// $COVERAGE-OFF$
+
 @implicitNotFound(msg = "No conversion rule for type ${T}\n" +
   "[NOTE] You need an implicit of getresult.TypeBinder[${T}] to convert the result.")
 sealed trait CheckGetter[+T]
@@ -49,6 +51,8 @@ object CheckGetter {
   implicit def valid[T](implicit binder: TypeBinder[T]): CheckGetter[T] =
     new CheckGetter[T] {}
 }
+
+// $COVERAGE-ON$
 
 trait TypeBinder[+T] {
   def apply(rs: ResultSet, index: Int): T
@@ -178,11 +182,13 @@ trait AutoUnwrapOption {
 }
 object AutoUnwrapOption extends AutoUnwrapOption
 
+// $COVERAGE-OFF$
+
 sealed trait IsNotOption[+T]
 object IsNotOption {
   implicit def some[T]: IsNotOption[T] = new IsNotOption[T] {}
-  // $COVERAGE-OFF$
   implicit def ambig1[T]: IsNotOption[Option[T]] = sys.error("unexpected")
   implicit def ambig2[T]: IsNotOption[Option[T]] = sys.error("unexpected")
-  // $COVERAGE-ON$
 }
+
+// $COVERAGE-ON$

--- a/src/main/scala/com/github/tarao/slickjdbc/interpolation/SetParameter.scala
+++ b/src/main/scala/com/github/tarao/slickjdbc/interpolation/SetParameter.scala
@@ -7,7 +7,10 @@ import scala.annotation.implicitNotFound
 import slick.jdbc.{SetParameter => SP, PositionedParameters}
 
 trait CompoundParameter {
-  implicit val createSetProduct: SP[Product] = SetProduct
+  implicit def createSetProduct[T](implicit
+    check1: T <:< Product,
+    check2: IsNotTuple[T]
+  ): SP[T] = new SetProduct[T]
 
   @inline implicit
   def createSetList[T](implicit c: SP[T]): SetList[T, NonEmpty[T]] =
@@ -23,10 +26,10 @@ class SetList[S, -T <: NonEmpty[S]](val c: SP[S]) extends SP[T] {
 }
 
 /** SetParameter for product types especially for case classes. */
-object SetProduct extends SP[Product] {
-  def apply(prod: Product, pp: PositionedParameters): Unit =
-    for (v <- prod.productIterator) v match {
-      case p: Product => SetProduct(p, pp)
+class SetProduct[-T](implicit product: T <:< Product) extends SP[T] {
+  def apply(prod: T, pp: PositionedParameters): Unit =
+    for (v <- product(prod).productIterator) v match {
+      case p: Product => new SetProduct[Product].apply(p, pp)
       case v => SP.SetSimpleProduct(Tuple1(v), pp)
     }
 }
@@ -64,34 +67,14 @@ object CheckNonEmpty {
     new CheckNonEmpty[T] {}
 }
 
-sealed trait NoOptionNonEmpty[-T]
-object NoOptionNonEmpty {
-  implicit def valid[T]: NoOptionNonEmpty[T] = new NoOptionNonEmpty[T] {}
-  // $COVERAGE-OFF$
-  implicit def ambig1[T]: NoOptionNonEmpty[Option[NonEmpty[T]]] =
-    sys.error("unexpected")
-  implicit def ambig2[T]: NoOptionNonEmpty[Option[NonEmpty[T]]] =
-    sys.error("unexpected")
-  // $COVERAGE-ON$
-}
-
 @implicitNotFound(msg = "A maybe-non-empty list is passed.\n" +
   "[NOTE] Break it into Some(_) or None to confirm that it is not empty.")
 sealed trait CheckOptionNonEmpty[-T]
 object CheckOptionNonEmpty {
   implicit def valid[T](implicit
-    check: NoOptionNonEmpty[T],
+    check: IsNotOptionNonEmpty[T],
     c: SP[T]
   ): CheckOptionNonEmpty[T] = new CheckOptionNonEmpty[T] {}
-}
-
-sealed trait NoOption[-T]
-object NoOption {
-  implicit def valid[T]: NoOption[T] = new NoOption[T] {}
-  // $COVERAGE-OFF$
-  implicit def ambig1[S]: NoOption[Option[S]] = sys.error("unexpected")
-  implicit def ambig2[S]: NoOption[Option[S]] = sys.error("unexpected")
-  // $COVERAGE-ON$
 }
 
 @implicitNotFound(msg = "Illegal parameter type: ${T}\n" +
@@ -100,7 +83,84 @@ object NoOption {
 sealed trait CheckOption[-T]
 object CheckOption {
   implicit def valid[T](implicit
-    check: NoOption[T],
+    check: IsNotOption[T],
     c: SP[T]
   ): CheckOption[T] = new CheckOption[T] {}
+}
+
+sealed trait IsNotOptionNonEmpty[-T]
+object IsNotOptionNonEmpty {
+  implicit def valid[T]: IsNotOptionNonEmpty[T] = new IsNotOptionNonEmpty[T] {}
+  // $COVERAGE-OFF$
+  implicit def ambig1[T]: IsNotOptionNonEmpty[Option[NonEmpty[T]]] =
+    sys.error("unexpected")
+  implicit def ambig2[T]: IsNotOptionNonEmpty[Option[NonEmpty[T]]] =
+    sys.error("unexpected")
+  // $COVERAGE-ON$
+}
+
+sealed trait IsNotOption[-T]
+object IsNotOption {
+  implicit def valid[T]: IsNotOption[T] = new IsNotOption[T] {}
+  // $COVERAGE-OFF$
+  implicit def ambig1[S]: IsNotOption[Option[S]] = sys.error("unexpected")
+  implicit def ambig2[S]: IsNotOption[Option[S]] = sys.error("unexpected")
+  // $COVERAGE-ON$
+}
+
+sealed trait IsNotTuple[-T]
+object IsNotTuple {
+  implicit def valid[T]: IsNotTuple[T] = new IsNotTuple[T] {}
+  // $COVERAGE-OFF$
+  implicit def ambig1[S](implicit tp: IsTuple[S]): IsNotTuple[S] =
+    sys.error("unexpected")
+  implicit def ambig2[S](implicit tp: IsTuple[S]): IsNotTuple[S] =
+    sys.error("unexpected")
+  // $COVERAGE-ON$
+}
+
+sealed trait IsTuple[-T]
+object IsTuple {
+  implicit def tuple2[T1, T2]: IsTuple[(T1, T2)] =
+    new IsTuple[(T1, T2)] {}
+  implicit def tuple3[T1, T2, T3]: IsTuple[(T1, T2, T3)] =
+    new IsTuple[(T1, T2, T3)] {}
+  implicit def tuple4[T1, T2, T3, T4]: IsTuple[(T1, T2, T3, T4)] =
+    new IsTuple[(T1, T2, T3, T4)] {}
+  implicit def tuple5[T1, T2, T3, T4, T5]: IsTuple[(T1, T2, T3, T4, T5)] =
+    new IsTuple[(T1, T2, T3, T4, T5)] {}
+  implicit def tuple6[T1, T2, T3, T4, T5, T6]: IsTuple[(T1, T2, T3, T4, T5, T6)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6)] {}
+  implicit def tuple7[T1, T2, T3, T4, T5, T6, T7]: IsTuple[(T1, T2, T3, T4, T5, T6, T7)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7)] {}
+  implicit def tuple8[T1, T2, T3, T4, T5, T6, T7, T8]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8)] {}
+  implicit def tuple9[T1, T2, T3, T4, T5, T6, T7, T8, T9]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9)] {}
+  implicit def tuple10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10)] {}
+  implicit def tuple11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11)] {}
+  implicit def tuple12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12)] {}
+  implicit def tuple13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13)] {}
+  implicit def tuple14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14)] {}
+  implicit def tuple15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15)] {}
+  implicit def tuple16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16)] {}
+  implicit def tuple17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17)] {}
+  implicit def tuple18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18)] {}
+  implicit def tuple19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19)] {}
+  implicit def tuple20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20)] {}
+  implicit def tuple21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21)] {}
+  implicit def tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)] =
+    new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)] {}
 }

--- a/src/main/scala/com/github/tarao/slickjdbc/interpolation/SetParameter.scala
+++ b/src/main/scala/com/github/tarao/slickjdbc/interpolation/SetParameter.scala
@@ -34,6 +34,8 @@ class SetProduct[-T](implicit product: T <:< Product) extends SP[T] {
     }
 }
 
+// $COVERAGE-OFF$
+
 @implicitNotFound(msg = "Unsupported parameter type: ${T}.\n" +
   "[NOTE] You need an implicit of slick.jdbc.SetParameter[${T}] to pass a value of the type.")
 sealed trait CheckParameter[-T]
@@ -91,32 +93,26 @@ object CheckOption {
 sealed trait IsNotOptionNonEmpty[-T]
 object IsNotOptionNonEmpty {
   implicit def valid[T]: IsNotOptionNonEmpty[T] = new IsNotOptionNonEmpty[T] {}
-  // $COVERAGE-OFF$
   implicit def ambig1[T]: IsNotOptionNonEmpty[Option[NonEmpty[T]]] =
     sys.error("unexpected")
   implicit def ambig2[T]: IsNotOptionNonEmpty[Option[NonEmpty[T]]] =
     sys.error("unexpected")
-  // $COVERAGE-ON$
 }
 
 sealed trait IsNotOption[-T]
 object IsNotOption {
   implicit def valid[T]: IsNotOption[T] = new IsNotOption[T] {}
-  // $COVERAGE-OFF$
   implicit def ambig1[S]: IsNotOption[Option[S]] = sys.error("unexpected")
   implicit def ambig2[S]: IsNotOption[Option[S]] = sys.error("unexpected")
-  // $COVERAGE-ON$
 }
 
 sealed trait IsNotTuple[-T]
 object IsNotTuple {
   implicit def valid[T]: IsNotTuple[T] = new IsNotTuple[T] {}
-  // $COVERAGE-OFF$
   implicit def ambig1[S](implicit tp: IsTuple[S]): IsNotTuple[S] =
     sys.error("unexpected")
   implicit def ambig2[S](implicit tp: IsTuple[S]): IsNotTuple[S] =
     sys.error("unexpected")
-  // $COVERAGE-ON$
 }
 
 sealed trait IsTuple[-T]
@@ -164,3 +160,5 @@ object IsTuple {
   implicit def tuple22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22]: IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)] =
     new IsTuple[(T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22)] {}
 }
+
+// $COVERAGE-ON$


### PR DESCRIPTION
`SetProduct` finally uses `slick.jdbc.SetParameter.SetSimpleProduct` to set product elements.  `SetSimpleProduct` handles only a few primitive types, which are determined at run time.  There is no room to make `SetSimpleProduct` to handle a user-defined type.

In contrast, tuples are handled by `slick.jdbc.SetParameter.createTupleN`, in which case the element types of a tuple are subject to searching implicit `SetParameter`s at compile time.  This gives us a chance to inject our custom `SetParameter` implicits for element types of tuples.

The problem was that `createSetProduct` had accidentally shadowed implicits of `createTupleN`.  This pull request fixes the problem by excluding tuples from targets of `createSetProduct`.
